### PR TITLE
[Task] Break mock-builder.component to sepearate smaller components

### DIFF
--- a/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.html
+++ b/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.html
@@ -1,0 +1,27 @@
+<h3>Request</h3>
+<div class="request-config-container">
+	<mat-form-field appearance="outline">
+		<mat-label>API type</mat-label>
+		<mat-select [(ngModel)]="requestType">
+			<mat-option value="{{RequestTypeEnum.GET}}">GET</mat-option>
+			<mat-option value="{{RequestTypeEnum.PUT}}">PUT</mat-option>
+			<mat-option value="{{RequestTypeEnum.POST}}">POST</mat-option>
+			<mat-option value="{{RequestTypeEnum.DELETE}}">DELETE</mat-option>
+		</mat-select>
+	</mat-form-field>
+	<mat-form-field appearance="outline" class="request-url-field">
+		<mat-label>API URL</mat-label>
+		<input matInput [(ngModel)]="requestUrl">
+	</mat-form-field>
+</div>
+<h3>Response</h3>
+<div class="response-config-container">
+	<ngx-monaco-editor [options]="monacoOptions"
+					   [(ngModel)]="responseBody"
+					   class="response-body-json-editor"
+	></ngx-monaco-editor>
+</div>
+<div class="mockinator-new-mock-actions">
+	<button mat-raised-button (click)="clearMockConfiguration()">Reset</button>
+	<button mat-raised-button color="primary" (click)="onSubmit()">Submit</button>
+</div>

--- a/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.scss
+++ b/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.scss
@@ -1,0 +1,40 @@
+@import '../../utils/mat-selectors';
+
+.app-api-mock-generator {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+
+	.request-config-container {
+		display: flex;
+		flex-direction: row;
+
+		mat-form-field {
+			padding: 0 15px;
+		}
+
+		.request-url-field {
+			width: 100%;
+		}
+	}
+
+	.response-config-container {
+		flex: 1;
+
+		.response-body-json-editor {
+			padding: 0 15px;
+			height: 100%;
+		}
+	}
+
+	.mockinator-new-mock-actions {
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-end;
+		padding: 6px 15px;
+
+		#{$mat-raised-button} {
+			margin: 0 10px;
+		}
+	}
+}

--- a/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.scss
+++ b/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.scss
@@ -1,5 +1,3 @@
-@import '../../utils/mat-selectors';
-
 .app-api-mock-generator {
 	height: 100%;
 	display: flex;
@@ -8,10 +6,7 @@
 	.request-config-container {
 		display: flex;
 		flex-direction: row;
-
-		mat-form-field {
-			padding: 0 15px;
-		}
+		column-gap: 10px;
 
 		.request-url-field {
 			width: 100%;
@@ -31,10 +26,7 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: flex-end;
+		column-gap: 10px;
 		padding: 6px 15px;
-
-		#{$mat-raised-button} {
-			margin: 0 10px;
-		}
 	}
 }

--- a/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.spec.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ApiMockConfigComponent } from './api-mock-config.component';
+
+describe('ApiMockGeneratorComponent', () => {
+  let component: ApiMockConfigComponent;
+  let fixture: ComponentFixture<ApiMockConfigComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApiMockConfigComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiMockConfigComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, inject, Output, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RequestType } from "../../models/request.type";
 import { MatButton } from "@angular/material/button";
@@ -10,6 +10,8 @@ import { MonacoEditorModule } from "ngx-monaco-editor-v2";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { RequestMock } from "../../models/request.mock";
 import { monacoOptions } from "../../utils";
+import { MockBuilderService } from "../../services";
+import { MatSnackBar } from "@angular/material/snack-bar";
 
 @Component({
 	selector: 'app-api-mock-config',
@@ -23,6 +25,9 @@ import { monacoOptions } from "../../utils";
 export class ApiMockConfigComponent {
 	protected readonly monacoOptions = monacoOptions;
 	protected readonly RequestTypeEnum = RequestType;
+	readonly mockBuilderService: MockBuilderService = inject(MockBuilderService);
+	readonly snackbarService: MatSnackBar = inject(MatSnackBar);
+
 
 	requestType = RequestType.GET;
 	requestUrl = '';
@@ -39,6 +44,8 @@ export class ApiMockConfigComponent {
 	onSubmit() {
 		const newMock = new RequestMock(this.requestType, this.requestUrl, this.responseBody);
 		this.onMockSubmit.emit(newMock);
+		this.mockBuilderService.addMock(newMock);
+		this.snackbarService.open('New mock added successfully', '', {duration: 5000});
 		this.clearMockConfiguration();
 	}
 }

--- a/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-generator/api-mock-config.component.ts
@@ -1,0 +1,44 @@
+import { Component, EventEmitter, Output, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RequestType } from "../../models/request.type";
+import { MatButton } from "@angular/material/button";
+import { MatFormField, MatLabel } from "@angular/material/form-field";
+import { MatInput } from "@angular/material/input";
+import { MatOption } from "@angular/material/autocomplete";
+import { MatSelect } from "@angular/material/select";
+import { MonacoEditorModule } from "ngx-monaco-editor-v2";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { RequestMock } from "../../models/request.mock";
+import { monacoOptions } from "../../utils";
+
+@Component({
+	selector: 'app-api-mock-config',
+	standalone: true,
+	imports: [CommonModule, MatButton, MatFormField, MatInput, MatLabel, MatOption, MatSelect, MonacoEditorModule, ReactiveFormsModule, FormsModule],
+	templateUrl: './api-mock-config.component.html',
+	styleUrl: './api-mock-config.component.scss',
+	encapsulation: ViewEncapsulation.None,
+	host: { class: 'app-api-mock-generator' },
+})
+export class ApiMockConfigComponent {
+	protected readonly monacoOptions = monacoOptions;
+	protected readonly RequestTypeEnum = RequestType;
+
+	requestType = RequestType.GET;
+	requestUrl = '';
+	responseBody = '';
+
+	@Output() onMockSubmit: EventEmitter<RequestMock> = new EventEmitter<RequestMock>();
+
+	clearMockConfiguration() {
+		this.requestType = RequestType.GET;
+		this.requestUrl = '';
+		this.responseBody = '';
+	}
+
+	onSubmit() {
+		const newMock = new RequestMock(this.requestType, this.requestUrl, this.responseBody);
+		this.onMockSubmit.emit(newMock);
+		this.clearMockConfiguration();
+	}
+}

--- a/projects/mock-builder/src/lib/components/api-mock-list/api-mock-list.component.html
+++ b/projects/mock-builder/src/lib/components/api-mock-list/api-mock-list.component.html
@@ -1,0 +1,47 @@
+<table mat-table [dataSource]="savedMocks"
+	   [multiTemplateDataRows]="true"
+	   class="saved-mocks">
+	<ng-container matColumnDef="type">
+		<th mat-header-cell *matHeaderCellDef>Request Type</th>
+		<td mat-cell *matCellDef="let mock"> {{ mock.type | uppercase }} </td>
+	</ng-container>
+
+	<ng-container matColumnDef="url">
+		<th mat-header-cell *matHeaderCellDef>Request URL</th>
+		<td mat-cell *matCellDef="let mock"> {{ mock.url }} </td>
+	</ng-container>
+
+	<ng-container matColumnDef="actions">
+		<th mat-header-cell *matHeaderCellDef aria-label="row actions">&nbsp;</th>
+		<td mat-cell *matCellDef="let mock">
+			<button mat-icon-button (click)="onTest(mock); $event.stopPropagation()">
+				<mat-icon>bug_report</mat-icon>
+			</button>
+			<button mat-icon-button (click)="onEdit(mock); $event.stopPropagation()">
+				<mat-icon>edit</mat-icon>
+			</button>
+			<button mat-icon-button (click)="onDelete(mock.id); $event.stopPropagation()" color="warn">
+				<mat-icon>delete</mat-icon>
+			</button>
+		</td>
+	</ng-container>
+
+	<ng-container matColumnDef="expandedDetail">
+		<td mat-cell *matCellDef="let mock" [attr.colspan]="columns.length">
+			<div *ngIf="expandedMock === mock" [@detailExpand]>
+				<div class="response-body-container">
+					<ngx-monaco-editor [options]="monacoOptionsReadOnly"
+									   [(ngModel)]="mock.body">
+					</ngx-monaco-editor>
+				</div>
+			</div>
+		</td>
+	</ng-container>
+	<tr mat-header-row *matHeaderRowDef="columns" class="mock-header"></tr>
+	<tr mat-row *matRowDef="let mock; columns: columns;"
+		class="mock-row"
+		[class.acc-expanded-row]="expandedMock === mock"
+		(click)="(expandedMock = expandedMock === mock ? null : mock); $event.stopPropagation()">
+	</tr>
+	<tr mat-row *matRowDef="let element; columns: ['expandedDetail']" class="response-body-row" [class.acc-expanded-row]="expandedMock === element"></tr>
+</table>

--- a/projects/mock-builder/src/lib/components/api-mock-list/api-mock-list.component.scss
+++ b/projects/mock-builder/src/lib/components/api-mock-list/api-mock-list.component.scss
@@ -1,0 +1,33 @@
+.app-api-mock-list {
+	.saved-mocks {
+		tr.response-body-row {
+			height: 0;
+		}
+
+		.response-body-container {
+			padding: 15px;
+		}
+
+		.mock-header,
+		.mock-row {
+			display: flex;
+			flex-direction: row;
+		}
+
+		.mat-column-type {
+			display: flex;
+			justify-content: center;
+			width: 20%;
+		}
+
+		.mat-column-url {
+			width: 70%;
+		}
+
+		.mat-column-actions {
+			display: flex;
+			justify-content: center;
+			width: 10%;
+		}
+	}
+}

--- a/projects/mock-builder/src/lib/components/api-mock-list/api-mock-list.component.spec.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-list/api-mock-list.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ApiMockListComponent } from './api-mock-list.component';
+
+describe('ApiMockListComponent', () => {
+  let component: ApiMockListComponent;
+  let fixture: ComponentFixture<ApiMockListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApiMockListComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiMockListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/mock-builder/src/lib/components/api-mock-list/api-mock-list.component.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-list/api-mock-list.component.ts
@@ -1,0 +1,87 @@
+import { Component, inject, OnDestroy, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+	MatCell,
+	MatCellDef,
+	MatColumnDef,
+	MatHeaderCell,
+	MatHeaderCellDef,
+	MatHeaderRow,
+	MatHeaderRowDef,
+	MatRow,
+	MatRowDef,
+	MatTable
+} from "@angular/material/table";
+import { MatIcon } from "@angular/material/icon";
+import { MatIconButton } from "@angular/material/button";
+import { MonacoEditorModule } from "ngx-monaco-editor-v2";
+import { RequestMock } from "../../models/request.mock";
+import { MockBuilderService } from "../../services";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { monacoOptionsReadOnly } from "../../utils";
+import { Subject, takeUntil } from "rxjs";
+import { FormsModule } from "@angular/forms";
+import { animate, style, transition, trigger } from "@angular/animations";
+
+@Component({
+	selector: 'app-api-mock-list',
+	standalone: true,
+	imports: [CommonModule, MatCell, MatCellDef, MatColumnDef, MatHeaderCell, MatHeaderRow, MatHeaderRowDef, MatIcon, MatIconButton, MatRow, MatRowDef, MatTable, MonacoEditorModule, FormsModule, MatHeaderCellDef],
+	templateUrl: './api-mock-list.component.html',
+	styleUrl: './api-mock-list.component.scss',
+	encapsulation: ViewEncapsulation.None,
+	host: {class: 'app-api-mock-list'},
+	animations: [
+		trigger('detailExpand', [
+			transition(':enter', [style({
+				height: '0px',
+				minHeight: '0'
+			}), animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)', style({height: '*'}))]),
+			transition(':leave', [style({height: '*'}), animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)', style({
+				height: '0',
+				minHeight: '0'
+			}))])
+		])
+	]
+})
+export class ApiMockListComponent implements OnInit, OnDestroy {
+	protected readonly monacoOptionsReadOnly = monacoOptionsReadOnly;
+	readonly mockBuilderService: MockBuilderService = inject(MockBuilderService);
+	readonly snackbarService: MatSnackBar = inject(MatSnackBar);
+
+	private onDestroy$ = new Subject<void>();
+
+	@ViewChild(MatTable, {static: true}) table!: MatTable<RequestMock>;
+
+	columns = ['type', 'url', 'actions'];
+	expandedMock: RequestMock | null = null;
+
+	savedMocks: RequestMock[] = [];
+
+	ngOnInit() {
+		this.mockBuilderService.savedMocks$.pipe(takeUntil(this.onDestroy$)).subscribe(savedMocks => {
+			this.savedMocks = savedMocks;
+			this.table.renderRows();
+		});
+	}
+
+	ngOnDestroy(): void {
+		this.onDestroy$.next();
+		this.onDestroy$.complete();
+	}
+
+	onTest(mock: RequestMock) {
+		this.mockBuilderService.testMock(mock).subscribe((response) => {
+			console.log(response);
+		});
+	}
+
+	onEdit(mock: RequestMock) {
+		console.log(mock);
+	}
+
+	onDelete(mockId: string) {
+		this.mockBuilderService.removeMock(mockId);
+		this.snackbarService.open('Mock removed successfully', '', {duration: 5000});
+	}
+}

--- a/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.html
+++ b/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.html
@@ -11,12 +11,12 @@
 		</mat-form-field>
 		<mat-form-field appearance="outline" class="request-url-field">
 			<mat-label>API URL</mat-label>
-			<input matInput [(ngModel)]="requestUrl">
+			<input matInput [(ngModel)]="requestUrl" (ngModelChange)="onUrlUpdated()">
 		</mat-form-field>
 	</div>
 	<div class="mock-actions">
-		<button mat-raised-button (click)="clearMockConfiguration()">Reset</button>
-		<button mat-raised-button color="primary" (click)="onTestMock()">Submit</button>
+		<button mat-raised-button (click)="clearMockConfiguration()" [disabled]="disableButton">Reset</button>
+		<button mat-raised-button color="primary" (click)="onTestMock()" [disabled]="disableButton">Submit</button>
 	</div>
 </div>
 <div class="response-container">

--- a/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.html
+++ b/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.html
@@ -1,0 +1,26 @@
+<div class="request-container">
+	<div class="request-details">
+		<mat-form-field appearance="outline">
+			<mat-label>API type</mat-label>
+			<mat-select [(ngModel)]="requestType">
+				<mat-option value="{{RequestTypeEnum.GET}}">GET</mat-option>
+				<mat-option value="{{RequestTypeEnum.PUT}}">PUT</mat-option>
+				<mat-option value="{{RequestTypeEnum.POST}}">POST</mat-option>
+				<mat-option value="{{RequestTypeEnum.DELETE}}">DELETE</mat-option>
+			</mat-select>
+		</mat-form-field>
+		<mat-form-field appearance="outline" class="request-url-field">
+			<mat-label>API URL</mat-label>
+			<input matInput [(ngModel)]="requestUrl">
+		</mat-form-field>
+	</div>
+	<div class="mock-actions">
+		<button mat-raised-button (click)="clearMockConfiguration()">Reset</button>
+		<button mat-raised-button color="primary" (click)="onTestMock()">Submit</button>
+	</div>
+</div>
+<div class="response-container">
+	<ngx-monaco-editor *ngIf="showResponseBody" [options]="monacoOptionsReadOnly"
+					   [(ngModel)]="responseBody"
+	></ngx-monaco-editor>
+</div>

--- a/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.scss
+++ b/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.scss
@@ -1,0 +1,33 @@
+.app-api-mock-test {
+	padding: 10px;
+	display: flex;
+	flex-direction: column;
+	row-gap: 10px;
+
+	.request-container {
+		display: flex;
+		flex-direction: column;
+
+		.request-details {
+			display: flex;
+			flex-direction: row;
+			width: 100%;
+			column-gap: 10px;
+
+			.request-url-field {
+				width: 100%;
+			}
+		}
+
+		.mock-actions {
+			display: flex;
+			flex-direction: row;
+			column-gap: 10px;
+
+			button {
+				flex: 1;
+			}
+		}
+	}
+
+}

--- a/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.spec.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ApiMockTestComponent } from './api-mock-test.component';
+
+describe('ApiMockTestComponent', () => {
+  let component: ApiMockTestComponent;
+  let fixture: ComponentFixture<ApiMockTestComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApiMockTestComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiMockTestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.ts
@@ -40,7 +40,7 @@ export class ApiMockTestComponent {
 	onTestMock() {
 		const mock = new RequestMock(this.requestType, this.requestUrl, '');
 		this.mockBuilderService.testMock(mock).subscribe((response) => {
-			this.responseBody = JSON.stringify(response);
+			this.responseBody = JSON.stringify(response, undefined, 2);
 			this.showResponseBody = StringUtils.isNotEmpty(this.responseBody);
 		});
 	}

--- a/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.ts
@@ -5,7 +5,7 @@ import { MatFormField, MatLabel } from "@angular/material/form-field";
 import { MatInput } from "@angular/material/input";
 import { MatOption } from "@angular/material/autocomplete";
 import { MatSelect } from "@angular/material/select";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { FormsModule } from "@angular/forms";
 import { MockBuilderService, monacoOptionsReadOnly, StringUtils } from "mock-builder";
 import { MonacoEditorModule } from "ngx-monaco-editor-v2";
 import { RequestMock } from "../../models/request.mock";
@@ -14,7 +14,7 @@ import { MatButton } from "@angular/material/button";
 @Component({
 	selector: 'app-api-mock-test',
 	standalone: true,
-	imports: [CommonModule, MatFormField, MatInput, MatLabel, MatOption, MatSelect, ReactiveFormsModule, FormsModule, MonacoEditorModule, MatButton],
+	imports: [CommonModule, MatFormField, MatInput, MatLabel, MatOption, MatSelect, FormsModule, MonacoEditorModule, MatButton],
 	templateUrl: './api-mock-test.component.html',
 	styleUrl: './api-mock-test.component.scss',
 	encapsulation: ViewEncapsulation.None,

--- a/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.ts
@@ -1,0 +1,47 @@
+import { Component, inject, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RequestType } from "../../models/request.type";
+import { MatFormField, MatLabel } from "@angular/material/form-field";
+import { MatInput } from "@angular/material/input";
+import { MatOption } from "@angular/material/autocomplete";
+import { MatSelect } from "@angular/material/select";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { MockBuilderService, monacoOptionsReadOnly, StringUtils } from "mock-builder";
+import { MonacoEditorModule } from "ngx-monaco-editor-v2";
+import { RequestMock } from "../../models/request.mock";
+import { MatButton } from "@angular/material/button";
+
+@Component({
+	selector: 'app-api-mock-test',
+	standalone: true,
+	imports: [CommonModule, MatFormField, MatInput, MatLabel, MatOption, MatSelect, ReactiveFormsModule, FormsModule, MonacoEditorModule, MatButton],
+	templateUrl: './api-mock-test.component.html',
+	styleUrl: './api-mock-test.component.scss',
+	encapsulation: ViewEncapsulation.None,
+	host: {class: 'app-api-mock-test'}
+})
+export class ApiMockTestComponent {
+	protected readonly monacoOptionsReadOnly = monacoOptionsReadOnly;
+	protected readonly RequestTypeEnum = RequestType;
+	readonly mockBuilderService: MockBuilderService = inject(MockBuilderService);
+
+	requestType = RequestType.GET;
+	requestUrl = '';
+	responseBody = '';
+	showResponseBody = false;
+
+	clearMockConfiguration() {
+		this.requestType = RequestType.GET;
+		this.requestUrl = '';
+		this.responseBody = '';
+		this.showResponseBody = false;
+	}
+
+	onTestMock() {
+		const mock = new RequestMock(this.requestType, this.requestUrl, '');
+		this.mockBuilderService.testMock(mock).subscribe((response) => {
+			this.responseBody = JSON.stringify(response);
+			this.showResponseBody = StringUtils.isNotEmpty(this.responseBody);
+		});
+	}
+}

--- a/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.ts
+++ b/projects/mock-builder/src/lib/components/api-mock-test/api-mock-test.component.ts
@@ -29,12 +29,14 @@ export class ApiMockTestComponent {
 	requestUrl = '';
 	responseBody = '';
 	showResponseBody = false;
+	disableButton: boolean = true;
 
 	clearMockConfiguration() {
 		this.requestType = RequestType.GET;
 		this.requestUrl = '';
 		this.responseBody = '';
 		this.showResponseBody = false;
+		this.disableButton = true;
 	}
 
 	onTestMock() {
@@ -43,5 +45,9 @@ export class ApiMockTestComponent {
 			this.responseBody = JSON.stringify(response, undefined, 2);
 			this.showResponseBody = StringUtils.isNotEmpty(this.responseBody);
 		});
+	}
+
+	onUrlUpdated() {
+		this.disableButton = StringUtils.isEmpty(this.requestUrl);
 	}
 }

--- a/projects/mock-builder/src/lib/components/index.ts
+++ b/projects/mock-builder/src/lib/components/index.ts
@@ -1,3 +1,5 @@
-export * from './mock-builder/mock-builder.component'
-export * from './api-mock-generator/api-mock-config.component'
-export * from './api-mock-list/api-mock-list.component'
+export * from './mock-builder/mock-builder.component';
+export * from './api-mock-generator/api-mock-config.component';
+export * from './api-mock-list/api-mock-list.component';
+export * from './api-mock-test/api-mock-test.component';
+

--- a/projects/mock-builder/src/lib/components/index.ts
+++ b/projects/mock-builder/src/lib/components/index.ts
@@ -1,3 +1,3 @@
 export * from './mock-builder/mock-builder.component'
-export * from './api-mock-generator/api-mock-generator.component'
-
+export * from './api-mock-generator/api-mock-config.component'
+export * from './api-mock-list/api-mock-list.component'

--- a/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.html
+++ b/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.html
@@ -5,7 +5,7 @@
 
   <mat-tab-group class="mockinator-tab-group">
     <mat-tab label="New Mock">
-		<app-api-mock-config (onMockSubmit)="onMockSubmit($event)"></app-api-mock-config>
+		<app-api-mock-config></app-api-mock-config>
     </mat-tab>
     <mat-tab label="Saved Mocks">
       	<app-api-mock-list></app-api-mock-list>

--- a/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.html
+++ b/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.html
@@ -5,82 +5,10 @@
 
   <mat-tab-group class="mockinator-tab-group">
     <mat-tab label="New Mock">
-      <h3>Request</h3>
-      <div class="request-config-container">
-        <mat-form-field appearance="outline">
-          <mat-label>API type</mat-label>
-          <mat-select [(ngModel)]="requestType">
-            <mat-option value="{{RequestTypeEnum.GET}}">GET</mat-option>
-            <mat-option value="{{RequestTypeEnum.PUT}}">PUT</mat-option>
-            <mat-option value="{{RequestTypeEnum.POST}}">POST</mat-option>
-            <mat-option value="{{RequestTypeEnum.DELETE}}">DELETE</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field appearance="outline" class="request-url-field">
-          <mat-label>API URL</mat-label>
-          <input matInput [(ngModel)]="requestUrl">
-        </mat-form-field>
-      </div>
-      <h3>Response</h3>
-      <div class="response-config-container">
-        <ngx-monaco-editor [options]="options"
-                           [(ngModel)]="responseBody"
-                           class="response-body-json-editor"
-        ></ngx-monaco-editor>
-      </div>
-      <div class="mockinator-new-mock-actions">
-        <button mat-raised-button (click)="clearMockConfiguration()">Reset</button>
-        <button mat-raised-button color="primary" (click)="onSubmit()">Submit</button>
-      </div>
+		<app-api-mock-config (onMockSubmit)="onMockSubmit($event)"></app-api-mock-config>
     </mat-tab>
     <mat-tab label="Saved Mocks">
-      <table mat-table [dataSource]="savedMocks"
-             [multiTemplateDataRows]="true"
-             class="saved-mocks">
-        <ng-container matColumnDef="type">
-          <th mat-header-cell *matHeaderCellDef>Request Type</th>
-          <td mat-cell *matCellDef="let mock"> {{ mock.type | uppercase }} </td>
-        </ng-container>
-
-        <ng-container matColumnDef="url">
-          <th mat-header-cell *matHeaderCellDef>Request URL</th>
-          <td mat-cell *matCellDef="let mock"> {{ mock.url }} </td>
-        </ng-container>
-
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef aria-label="row actions">&nbsp;</th>
-          <td mat-cell *matCellDef="let mock">
-            <button mat-icon-button (click)="onTest(mock); $event.stopPropagation()">
-              <mat-icon>bug_report</mat-icon>
-            </button>
-            <button mat-icon-button (click)="onEdit(mock); $event.stopPropagation()">
-              <mat-icon>edit</mat-icon>
-            </button>
-            <button mat-icon-button (click)="onDelete(mock.id); $event.stopPropagation()" color="warn">
-              <mat-icon>delete</mat-icon>
-            </button>
-          </td>
-        </ng-container>
-
-        <ng-container matColumnDef="expandedDetail">
-          <td mat-cell *matCellDef="let mock" [attr.colspan]="columns.length">
-            <div *ngIf="expandedMock === mock" [@detailExpand]>
-              <div class="response-body-container">
-                <ngx-monaco-editor [options]="optionsReadOnly"
-                                   [(ngModel)]="mock.body">
-                </ngx-monaco-editor>
-              </div>
-            </div>
-          </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="columns" class="mock-header"></tr>
-        <tr mat-row *matRowDef="let mock; columns: columns;"
-            class="mock-row"
-            [class.acc-expanded-row]="expandedMock === mock"
-            (click)="(expandedMock = expandedMock === mock ? null : mock); $event.stopPropagation()">
-        </tr>
-        <tr mat-row *matRowDef="let element; columns: ['expandedDetail']" class="response-body-row" [class.acc-expanded-row]="expandedMock === element"></tr>
-      </table>
+      	<app-api-mock-list></app-api-mock-list>
     </mat-tab>
   </mat-tab-group>
 </div>

--- a/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.html
+++ b/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.html
@@ -7,6 +7,9 @@
     <mat-tab label="New Mock">
 		<app-api-mock-config></app-api-mock-config>
     </mat-tab>
+    <mat-tab label="Test Mock">
+		<app-api-mock-test></app-api-mock-test>
+    </mat-tab>
     <mat-tab label="Saved Mocks">
       	<app-api-mock-list></app-api-mock-list>
     </mat-tab>

--- a/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.scss
+++ b/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.scss
@@ -1,105 +1,40 @@
 @import '../../utils/mat-selectors';
 
 .mockinator-container {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 
-  .mockinator-header {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    padding: 20px;
-  }
+	.mockinator-header {
+		display: flex;
+		flex-direction: row;
+		justify-content: center;
+		padding: 20px;
+	}
 
-  .mockinator-tab-group {
-    width: 100%;
-    flex: 1;
-  }
+	.mockinator-tab-group {
+		width: 100%;
+		flex: 1;
+	}
 
-  #{$mat-tab-group}#{$mat-tab-group-stretch} {
-    #{$mat-tab-header} #{$mat-tab-label}:is(div) {
-      flex-grow: 1;
-    }
+	#{$mat-tab-group}#{$mat-tab-group-stretch} {
+		#{$mat-tab-header} #{$mat-tab-label}:is(div) {
+			flex-grow: 1;
+		}
 
-    #{$mat-tab-body} {
-      padding: 15px;
-      display: flex;
-      flex-direction: column;
-    }
+		#{$mat-tab-body} {
+			padding: 15px;
+			display: flex;
+			flex-direction: column;
+		}
 
-    #{$mat-tab-body-wrapper} {
-      flex: 1;
-    }
+		#{$mat-tab-body-wrapper} {
+			flex: 1;
+		}
 
-    #{$mat-tab-body-content} {
-      display: flex;
-      flex-direction: column;
-    }
-  }
-
-  .request-config-container {
-    display: flex;
-    flex-direction: row;
-
-    mat-form-field {
-      padding: 0 15px;
-    }
-
-    .request-url-field {
-      width: 100%;
-    }
-  }
-
-  .response-config-container {
-    flex: 1;
-
-    .response-body-json-editor {
-      padding: 0 15px;
-      height: 100%;
-    }
-  }
-
-  .mockinator-new-mock-actions {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    padding: 6px 15px;
-
-    #{$mat-raised-button} {
-      margin: 0 10px;
-    }
-  }
-
-  .saved-mocks {
-    tr.response-body-row {
-      height: 0;
-    }
-
-    .response-body-container {
-      padding: 15px;
-    }
-
-    .mock-header,
-    .mock-row {
-      display: flex;
-      flex-direction: row;
-    }
-
-    .mat-column-type {
-      display: flex;
-      justify-content: center;
-      width: 20%;
-    }
-
-    .mat-column-url {
-      width: 70%;
-    }
-
-    .mat-column-actions {
-      display: flex;
-      justify-content: center;
-      width: 10%;
-    }
-  }
+		#{$mat-tab-body-content} {
+			display: flex;
+			flex-direction: column;
+		}
+	}
 }

--- a/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.ts
+++ b/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.ts
@@ -1,120 +1,33 @@
-import { Component, ViewChild, ViewEncapsulation } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { MatButtonModule } from '@angular/material/button';
-import { MatTable, MatTableModule } from '@angular/material/table';
-import { MatIconModule } from '@angular/material/icon';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
+import { Component, inject, ViewEncapsulation } from '@angular/core';
 import { MatTabsModule } from '@angular/material/tabs';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
-import { CommonModule, NgIf, UpperCasePipe } from '@angular/common';
-import { Subject, takeUntil } from 'rxjs';
+import { CommonModule } from '@angular/common';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { RouterOutlet } from '@angular/router';
 import { MockBuilderService } from '../../services';
-import { RequestType } from '../../models/request.type';
 import { RequestMock } from '../../models/request.mock';
-import { animate, style, transition, trigger } from '@angular/animations';
+import { ApiMockConfigComponent } from "../api-mock-generator/api-mock-config.component";
+import { ApiMockListComponent } from "../api-mock-list/api-mock-list.component";
 
 @Component({
-  selector: 'mock-builder',
-  providers: [MockBuilderService],
-  standalone: true,
-  imports: [
-    CommonModule,
-    RouterOutlet,
-    MatButtonModule,
-    MatIconModule,
-    MatTabsModule,
-    MatSelectModule,
-    FormsModule,
-    MatInputModule,
-    MonacoEditorModule,
-    MatTableModule,
-    NgIf,
-    UpperCasePipe,
-  ],
-  templateUrl: './mock-builder.component.html',
-  styleUrl: './mock-builder.component.scss',
-  encapsulation: ViewEncapsulation.None,
-  animations: [
-    trigger('detailExpand', [
-      transition(':enter', [style({ height: '0px', minHeight: '0' }), animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)', style({ height: '*' }))]),
-      transition(':leave', [style({ height: '*' }), animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)', style({ height: '0', minHeight: '0' }))])
-    ])
-  ]
+	selector: 'mock-builder',
+	providers: [MockBuilderService],
+	standalone: true,
+	imports: [
+		CommonModule,
+		MatTabsModule,
+		ApiMockConfigComponent,
+		ApiMockListComponent,
+	],
+	templateUrl: './mock-builder.component.html',
+	styleUrl: './mock-builder.component.scss',
+	encapsulation: ViewEncapsulation.None,
 })
 export class MockBuilderComponent {
-  public readonly options = {
-    theme: 'vs-dark',
-    language: 'json',
-    formatOnType: true,
-    minimap: {
-      enabled: false
-    },
-    wordWrap: 'on',
-    folding: true,
-    showFoldingControls: 'always'
-  };
-  public readonly optionsReadOnly = {
-    ...this.options,
-    readOnly: true
-  };
 
-  private onDestroy$ = new Subject<void>();
+	readonly mockBuilderService: MockBuilderService = inject(MockBuilderService);
+	readonly snackbarService: MatSnackBar = inject(MatSnackBar);
 
-  RequestTypeEnum = RequestType;
-  requestType = RequestType.GET;
-  requestUrl = '';
-  responseBody = '';
-
-  columns = ['type', 'url', 'actions'];
-  expandedMock: RequestMock | null = null;
-
-  savedMocks: RequestMock[] = [];
-
-  @ViewChild(MatTable, { static: true }) table!: MatTable<RequestMock>;
-
-  constructor(private mockBuilderService: MockBuilderService,
-              private snackbarService: MatSnackBar) {}
-
-  ngOnInit() {
-    this.mockBuilderService.savedMocks$.pipe(takeUntil(this.onDestroy$)).subscribe(savedMocks => {
-      this.savedMocks = savedMocks;
-      this.table.renderRows();
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.onDestroy$.next();
-    this.onDestroy$.complete();
-  }
-
-  clearMockConfiguration() {
-    this.requestType = RequestType.GET;
-    this.requestUrl = '';
-    this.responseBody = '';
-  }
-
-  onSubmit() {
-    const newMock = new RequestMock(this.requestType, this.requestUrl, this.responseBody);
-    this.mockBuilderService.addMock(newMock);
-    this.clearMockConfiguration();
-    this.snackbarService.open('New mock added successfully', '', { duration: 5000 });
-  }
-
-  onTest(mock: RequestMock) {
-    this.mockBuilderService.testMock(mock).subscribe((response) => {
-      console.log(response);
-    });
-  }
-
-  onEdit(mock: RequestMock) {
-    console.log(mock);
-  }
-
-  onDelete(mockId: string) {
-    this.mockBuilderService.removeMock(mockId);
-    this.snackbarService.open('Mock removed successfully', '', { duration: 5000 });
-  }
+	onMockSubmit(newMock: RequestMock) {
+		this.mockBuilderService.addMock(newMock);
+		this.snackbarService.open('New mock added successfully', '', {duration: 5000});
+	}
 }

--- a/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.ts
+++ b/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { MockBuilderService } from '../../services';
 import { ApiMockConfigComponent } from "../api-mock-generator/api-mock-config.component";
 import { ApiMockListComponent } from "../api-mock-list/api-mock-list.component";
+import { ApiMockTestComponent } from "../api-mock-test/api-mock-test.component";
 
 @Component({
 	selector: 'mock-builder',
@@ -14,6 +15,7 @@ import { ApiMockListComponent } from "../api-mock-list/api-mock-list.component";
 		MatTabsModule,
 		ApiMockConfigComponent,
 		ApiMockListComponent,
+		ApiMockTestComponent,
 	],
 	templateUrl: './mock-builder.component.html',
 	styleUrl: './mock-builder.component.scss',

--- a/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.ts
+++ b/projects/mock-builder/src/lib/components/mock-builder/mock-builder.component.ts
@@ -1,9 +1,7 @@
-import { Component, inject, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { MatTabsModule } from '@angular/material/tabs';
 import { CommonModule } from '@angular/common';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MockBuilderService } from '../../services';
-import { RequestMock } from '../../models/request.mock';
 import { ApiMockConfigComponent } from "../api-mock-generator/api-mock-config.component";
 import { ApiMockListComponent } from "../api-mock-list/api-mock-list.component";
 
@@ -22,12 +20,4 @@ import { ApiMockListComponent } from "../api-mock-list/api-mock-list.component";
 	encapsulation: ViewEncapsulation.None,
 })
 export class MockBuilderComponent {
-
-	readonly mockBuilderService: MockBuilderService = inject(MockBuilderService);
-	readonly snackbarService: MatSnackBar = inject(MatSnackBar);
-
-	onMockSubmit(newMock: RequestMock) {
-		this.mockBuilderService.addMock(newMock);
-		this.snackbarService.open('New mock added successfully', '', {duration: 5000});
-	}
 }

--- a/projects/mock-builder/src/lib/utils/constants.ts
+++ b/projects/mock-builder/src/lib/utils/constants.ts
@@ -1,0 +1,15 @@
+export const monacoOptions = {
+	theme: 'vs-dark',
+	language: 'json',
+	formatOnType: true,
+	minimap: {
+		enabled: false
+	},
+	wordWrap: 'on',
+	folding: true,
+	showFoldingControls: 'always'
+};
+export const monacoOptionsReadOnly = {
+	monacoOptions,
+	readOnly: true
+};

--- a/projects/mock-builder/src/lib/utils/index.ts
+++ b/projects/mock-builder/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 // export * from './mat-selectors.scss';
 
 export * from './mock-service-worker';
-export * from './constants'
+export * from './constants';
+export * from './string-utils';

--- a/projects/mock-builder/src/lib/utils/index.ts
+++ b/projects/mock-builder/src/lib/utils/index.ts
@@ -1,2 +1,4 @@
+// export * from './mat-selectors.scss';
+
 export * from './mock-service-worker';
-export * from './mat-selectors.scss';
+export * from './constants'

--- a/projects/mock-builder/src/lib/utils/string-utils.ts
+++ b/projects/mock-builder/src/lib/utils/string-utils.ts
@@ -1,0 +1,9 @@
+export class StringUtils {
+	public static isEmpty(str: string) {
+		return str.trim() === '';
+	}
+
+	public static isNotEmpty(str: string) {
+		return !this.isEmpty(str);
+	}
+}


### PR DESCRIPTION
**What is the type of this contribution?**

>- [x] Task
>- [ ] Feature
>- [ ] Bugfix


**Are all the contribution pre-requisites successful?**

>- [ ] Lint
>- [ ] Unit tests
>- [x] Build

- [x] **The commit messages follow the guidelines**
- [x] **Branch names follow naming convention**
- [ ] **Tests have been added for the changes introduced in this PR**
- [ ] **This contribution introduces a breaking change**

**Other information**
Break mock-builder.component into mock-generator, meck-tester, and mock-list components. This is done to prepare for future deprecation of mock-builder.component
Unit tests for all components will be added in a future PR