### PR TITLE
[Task] Resolved issue where app start would fail giving error on colors.scss import in app.component.scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@angular/platform-browser": "^17.0.0",
     "@angular/platform-browser-dynamic": "^17.0.0",
     "@angular/router": "^17.0.0",
-    "mock-builder": "file:dist/mock-builder/mock-builder-0.0.1.tgz",
     "monaco-editor": "^0.44.0",
     "msw": "^2.3.1",
     "ngx-monaco-editor-v2": "^17.0.1",

--- a/project.json
+++ b/project.json
@@ -30,7 +30,10 @@
           "@angular/material/prebuilt-themes/indigo-pink.css",
           "src/styles.css"
         ],
-        "scripts": []
+        "scripts": [],
+        "stylePreprocessorOptions": {
+					"includePaths": ["projects/mock-builder/src/lib/styles"]
+				}
       },
       "configurations": {
         "production": {
@@ -90,7 +93,10 @@
           "@angular/material/prebuilt-themes/indigo-pink.css",
           "src/styles.css"
         ],
-        "scripts": []
+        "scripts": [],
+        "stylePreprocessorOptions": {
+					"includePaths": ["projects/mock-builder/src/lib/styles"]
+				}
       }
     }
   }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,4 +1,4 @@
-@import 'mock-builder/styles/colors.scss';
+@import 'colors';
 
 .app-root {
 	display: flex;


### PR DESCRIPTION
**What is the type of this contribution?**

>- [x] Task
>- [ ] Feature
>- [ ] Bug


**Are all the contribution pre-requisites successful?**

>- [ ] Lint - NA
>- [ ] Unit tests - NA
>- [x] Build

- [x] **The commit messages follow the guidelines** ([guidelines](https://github.com/swapnil28verma/mockinator/wiki/Contribution-guidelines#commit-guidelines))
- [x] **Branch names follow naming convention** ([guidelines](https://github.com/swapnil28verma/mockinator/wiki/Contribution-guidelines#branch-naming-convention))
- [x] **Pull request template follow the guidelines** ([guidelines](https://github.com/swapnil28verma/mockinator/wiki/Contribution-guidelines#pull-request-guidelines))
- [x] **Necessary labels have been added to the PR** (tag, bug or feature)
- [ ] **Tests have been added for the changes introduced in this PR** - NA
- [ ] **This contribution introduces a breaking change**

**Other information**
Fixed a configuration issue where running npm start would cause an error on the import statmement for colors.scss in app.component.scss